### PR TITLE
bdd(volume-event-controller): add sanity test to verify volume-event-exporter exported data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,44 @@ jobs:
       - name: Upload Coverage Report
         uses: codecov/codecov-action@v1
 
+  sanity-test:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
+    runs-on: ubuntu-latest
+    needs: ['unit-test']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.7
+
+      - name: Setup Minikube-Kubernetes
+        uses: manusa/actions-setup-minikube@v2.3.0
+        with:
+          minikube version: v1.16.0
+          kubernetes version: v1.20.1
+
+      - name: Build volume-event-controller image
+        run: make volume-events-exporter-image
+
+      - name: Install NFS utils
+        run: |
+          sudo apt-get update
+          sudo apt install nfs-common
+
+      - name: Installation
+        run: |
+          ./tests/install-nfs-operator.sh
+
+      - name: Running sanity tests
+        run: make sanity-test
+
   volume-event-controller:
     runs-on: ubuntu-latest
-    needs: ['lint', 'unit-test']
+    needs: ['sanity-test']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -86,3 +86,38 @@ jobs:
           platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
           tags: |
             mayadataio/volume-event-exporter:ci
+
+  sanity-test:
+    # to ignore builds on release
+    if: ${{ (github.event.ref_type != 'tag') }}
+    runs-on: ubuntu-latest
+    needs: ['volume-event-controller']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14.7
+
+      - name: Setup Minikube-Kubernetes
+        uses: manusa/actions-setup-minikube@v2.3.0
+        with:
+          minikube version: v1.16.0
+          kubernetes version: v1.20.1
+
+      - name: Build volume-event-controller image
+        run: make volume-events-exporter-image
+
+      - name: Install NFS utils
+        run: |
+          sudo apt-get update
+          sudo apt install nfs-common
+
+      - name: Installation
+        run: |
+          ./tests/install-nfs-operator.sh
+
+      - name: Running sanity tests
+        run: make sanity-test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  skip-files:
+    - "tests/k8s_utils.go"
 linters-settings:
   revive:
     ignore-generated-header: true

--- a/Makefile
+++ b/Makefile
@@ -185,6 +185,11 @@ license-check:
 	@echo "--> Done checking license."
 	@echo
 
+.PHONY: sanity-test
+sanity-test: sanity-test
+	@echo "--> Running sanity test";
+	go test -v -timeout 40m ./tests/...
+
 .PHONY: clean
 clean:
 	@echo "--> Cleaning Directory"

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -165,6 +165,7 @@ spec:
         image: mayadataio/volume-events-exporter:ci
         args:
           - "--leader-election=false"
+          - "--generate-k8s-events=true"
         env:
         # OPENEBS_IO_NFS_SERVER_NS defines the namespace of nfs-server deployment
         #- name: OPENEBS_IO_NFS_SERVER_NS

--- a/go.mod
+++ b/go.mod
@@ -13,5 +13,6 @@ require (
 	k8s.io/api v0.21.3
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
+	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.10.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,11 @@ module github.com/mayadata-io/volume-events-exporter
 go 1.16
 
 require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/google/go-cmp v0.5.4
+	github.com/gorilla/mux v1.8.0
+	github.com/onsi/ginkgo v1.11.0
+	github.com/onsi/gomega v1.7.0
 	github.com/openebs/api/v2 v2.3.0
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.21.3

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,7 @@ cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go v0.52.0/go.mod h1:pXajvRH/6o3+F9jDHZWQ5PbGhn+o8w9qiu/CffaVdO4=
 cloud.google.com/go v0.53.0/go.mod h1:fp/UouUEsRkN6ryDKNW/Upv/JBKnv6WDthjR6+vze6M=
+cloud.google.com/go v0.54.0 h1:3ithwDMr7/3vpAMXiH+ZQnYbuIsh+OPhUPMFC9enmn0=
 cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bPc=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -46,6 +47,7 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
@@ -127,6 +129,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gnostic v0.4.1 h1:DLJCy1n/vrD4HPjOvYcT8aYQXpPIzoRZONaYwyycI+I=
 github.com/googleapis/gnostic v0.4.1/go.mod h1:LRhVm6pbyptWbWbuZ38d1eyptfvIytN3ir6b65WBswg=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
+github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,28 @@
+# Integration Test
+
+Volume-event-exporter makes use of ginkgo & gomega libraries to implement its integration tests.
+
+To run the integrations test:
+1. Copy kubeconfig file into path ~/.kube/config or set the KUBECONFIG env.
+2. Run `make sanity-test`
+
+**Note**:
+- Integration test will spin up RPC server and will tear down server at end of the test. By default server will run on 9090 port and it can configured with option `--port`.
+- To run a specific test following command can be used:
+  ```sh
+  ginkgo -v -focus="TEST NFS PVC CREATE & DELTE EVENTS" -- -address=172.18.0.1 -port=9091
+  ```
+  In above `-focus` can have test name
+
+Following parameters can be configured as a arguments to test:
+- kubeconfig: Path to kubeconfig to interact with Kubernetes APIServer.
+- address: Address on which server will start(Defaults to system IPAddress).
+- port: Server port on which requests are served
+- type: Defines the type of the RPC server, as of now only RESTfull server is supported.
+
+
+Available Integration Tests:
+| Test Name       | Expected behavior | Test Link  |
+| --------------- | ----------------- | ---------- |
+| Create NFS PVC with reclaim policy Delete | <ul> Verify whether volume_event_controller sent volume_provisioned JSON data to configured server <li> nfs_pvc </li> <li> nfs_pv </li> <li> backend_pvc </li> <li> backend_pv </li> along with creationTimestamp on `nfs_pv` </ul>| [nfs_sanity_test.go](./nfs_sanity_test.go) |
+| Delete NFS PVC with reclaim policy Delete | <ul> Verify whether volume_event_controller sent volume_deprovisioned JSON data to configured server <li> nfs_pv </li> <li> backend_pvc </li> <li> backend_pvc </li> along with creation and deletion timestamp on `nfs_pv` </ul> | [nfs_sanity_test.go](./nfs_sanity_test.go) |

--- a/tests/install-nfs-operator.sh
+++ b/tests/install-nfs-operator.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+mkdir -p /tmp/openebs
+kubectl  apply -f https://raw.githubusercontent.com/openebs/dynamic-localpv-provisioner/v2.12.0/deploy/kubectl/hostpath-operator.yaml
+wget https://raw.githubusercontent.com/openebs/dynamic-localpv-provisioner/v2.12.0/deploy/kubectl/openebs-hostpath-sc.yaml -O /tmp/openebs-lite-sc.yaml
+sed -i  's/value\: \"\/var\/openebs\/local\/\"/value\: \"\/tmp\/openebs\/\"/' /tmp/openebs-lite-sc.yaml
+
+function waitForDeployment() {
+	DEPLOY=$1
+	NS=$2
+	CREATE=true
+
+	if [ $# -eq 3 ] && ! $3 ; then
+		CREATE=false
+	fi
+
+	for i in $(seq 1 50) ; do
+		kubectl get deployment -n ${NS} ${DEPLOY}
+		kstat=$?
+		if [ $kstat -ne 0 ] && ! $CREATE ; then
+			return
+		elif [ $kstat -eq 0 ] && ! $CREATE; then
+			sleep 3
+			continue
+		fi
+
+		replicas=$(kubectl get deployment -n ${NS} ${DEPLOY} -o jsonpath='{.status.readyReplicas}')
+		if [ "$replicas" == "1" ]; then
+			break
+		else
+			echo "Waiting for ${DEPLOY} to be ready"
+			kubectl logs deploy/${DEPLOY} -n ${NS}
+			sleep 10
+		fi
+	done
+}
+
+kubectl apply -f /tmp/openebs-lite-sc.yaml
+waitForDeployment openebs-localpv-provisioner openebs
+
+sed -i 's/#- name: BackendStorageClass/- name: BackendStorageClass/' deploy/kubectl/openebs-nfs-provisioner.yaml
+sed -i 's/#  value: "openebs-hostpath"/  value: "openebs-hostpath"/' deploy/kubectl/openebs-nfs-provisioner.yaml
+
+kubectl  apply -f deploy/kubectl/openebs-nfs-provisioner.yaml
+
+waitForDeployment openebs-nfs-provisioner openebs
+kubectl get sc -o yaml

--- a/tests/install-nfs-operator.sh
+++ b/tests/install-nfs-operator.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+Copyright © 2021 The MayaData Authors
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 mkdir -p /tmp/openebs
 kubectl  apply -f https://raw.githubusercontent.com/openebs/dynamic-localpv-provisioner/v2.12.0/deploy/kubectl/hostpath-operator.yaml
 wget https://raw.githubusercontent.com/openebs/dynamic-localpv-provisioner/v2.12.0/deploy/kubectl/openebs-hostpath-sc.yaml -O /tmp/openebs-lite-sc.yaml

--- a/tests/install-nfs-operator.sh
+++ b/tests/install-nfs-operator.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-Copyright © 2021 The MayaData Authors
+# Copyright © 2021 The MayaData Authors
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/k8s_utils.go
+++ b/tests/k8s_utils.go
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// NOTE: This file is ctrl+v from https://github.com/openebs/dynamic-nfs-provisioner/blob/develop/tests/k8s_utils.go
+// NOTE: This file is copied from
+//		 https://github.com/openebs/dynamic-nfs-provisioner/blob/0e0a8707cd9c952a62ac9d898055628a42ca6e58/tests/k8s_utils.go
+//       and modified according to k8s lib version
 
 package tests
 

--- a/tests/k8s_utils.go
+++ b/tests/k8s_utils.go
@@ -1,0 +1,511 @@
+/*
+Copyright © 2021 The MayaData Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// NOTE: This file is ctrl+v from https://github.com/openebs/dynamic-nfs-provisioner/blob/develop/tests/k8s_utils.go
+
+package tests
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	types "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/reference"
+)
+
+// KubeClient interface for k8s API
+type KubeClient struct {
+	kubernetes.Interface
+	config *rest.Config
+}
+
+var (
+	// Client for KubeClient
+	Client *KubeClient
+
+	// encoder to print object in yaml format
+	encoder runtime.Encoder
+
+	// defaultChunkSize is a maximum number of responses to
+	// return for a list call. If still resources exist then
+	// server will set continue field in listOptions so it is
+	// responsibility of client to fetch further responses if
+	// continue field is set
+	defaultChunkSize = int64(500)
+	metadataAccessor = meta.NewAccessor()
+)
+
+// getHomeDir gets the home directory for the system.
+// It is required to locate the .kube/config file
+func getHomeDir() (string, error) {
+	if h := os.Getenv("HOME"); h != "" {
+		return h, nil
+	}
+
+	return "", fmt.Errorf("not able to locate home directory")
+}
+
+// getConfigPath returns the filepath of kubeconfig file
+func getConfigPath() (string, error) {
+	home, err := getHomeDir()
+	if err != nil {
+		return "", err
+	}
+	kubeConfigPath := home + "/.kube/config"
+	return kubeConfigPath, nil
+}
+
+func initK8sClient(kubeConfigPath string) error {
+	var err error
+	if kubeConfigPath == "" {
+		kubeConfigPath, err = getConfigPath()
+		if err != nil {
+			return err
+		}
+	}
+
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		return err
+	}
+
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil
+	}
+
+	scheme := runtime.NewScheme()
+	serializerInfo, found := runtime.SerializerInfoForMediaType(serializer.NewCodecFactory(scheme).SupportedMediaTypes(), "application/yaml")
+	if found {
+		encoder = serializerInfo.Serializer
+	}
+
+	Client = &KubeClient{
+		Interface: client,
+		config:    config,
+	}
+	return nil
+}
+
+func (k *KubeClient) waitForPods(podNamespace, labelSelector string, expectedPhase corev1.PodPhase, expectedCount int) error {
+	dumpLog := 0
+	for {
+		podList, err := k.CoreV1().Pods(podNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return err
+		}
+
+		count := 0
+		for _, pod := range podList.Items {
+			if pod.Status.Phase == expectedPhase {
+				count++
+			}
+		}
+
+		if count == expectedCount {
+			break
+		}
+
+		time.Sleep(5 * time.Second)
+
+		if dumpLog > 6 {
+			fmt.Printf("checking for pod with labelSelector=%s in ns=%s, count=%d expectedCount=%d\n", labelSelector, podNamespace, count, expectedCount)
+			dumpLog = 0
+		}
+		dumpLog++
+	}
+	return nil
+}
+
+func (k *KubeClient) listPods(podNamespace string, labelSelector string) (*corev1.PodList, error) {
+	return k.CoreV1().Pods(podNamespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+}
+
+func (k *KubeClient) createNamespace(namespace string) error {
+	_, err := k.CoreV1().Namespaces().Get(context.TODO(), namespace, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			o := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			_, err = k.CoreV1().Namespaces().Create(context.TODO(), o, metav1.CreateOptions{})
+		}
+	}
+	return err
+}
+
+// WaitForNamespaceCleanup wait for cleanup of the given namespace
+func (k *KubeClient) WaitForNamespaceCleanup(ns string) error {
+	dumpLog := 0
+	for {
+		nsObj, err := k.CoreV1().Namespaces().Get(context.TODO(), ns, metav1.GetOptions{})
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if dumpLog > 6 {
+			fmt.Printf("Waiting for cleanup of namespace %s\n", ns)
+			dumpK8sObject(nsObj)
+			dumpLog = 0
+		}
+
+		dumpLog++
+		time.Sleep(5 * time.Second)
+	}
+}
+
+func (k *KubeClient) destroyNamespace(namespace string) error {
+	err := k.CoreV1().Namespaces().Delete(context.TODO(), namespace, metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		return k.WaitForNamespaceCleanup(namespace)
+	}
+	return nil
+}
+
+func (k *KubeClient) waitForPVCBound(ns, pvcName string) (corev1.PersistentVolumeClaimPhase, error) {
+	for {
+		o, err := k.CoreV1().
+			PersistentVolumeClaims(ns).
+			Get(context.TODO(), pvcName, metav1.GetOptions{})
+		if err != nil {
+			return "", err
+		}
+
+		if o.Status.Phase == corev1.ClaimLost {
+			return o.Status.Phase, errors.Errorf("PVC %s/%s in lost state", ns, pvcName)
+		}
+		if o.Status.Phase == corev1.ClaimBound {
+			return o.Status.Phase, nil
+		}
+		fmt.Printf("waiting for PVC {%s} in namespace {%s} to get into bound state\n", pvcName, ns)
+		time.Sleep(5 * time.Second)
+	}
+}
+
+// createPVC will create PVC and it will not wait for PVC to get bound
+func (k *KubeClient) createPVC(pvc *corev1.PersistentVolumeClaim) error {
+	_, err := k.CoreV1().PersistentVolumeClaims(pvc.Namespace).Create(context.TODO(), pvc, metav1.CreateOptions{})
+	if err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (k *KubeClient) getPVC(pvcNamespace, pvcName string) (*corev1.PersistentVolumeClaim, error) {
+	return k.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
+}
+
+func (k *KubeClient) updatePVC(pvcObj *corev1.PersistentVolumeClaim) (*corev1.PersistentVolumeClaim, error) {
+	return k.CoreV1().PersistentVolumeClaims(pvcObj.Namespace).Update(context.TODO(), pvcObj, metav1.UpdateOptions{})
+}
+
+func (k *KubeClient) deletePVC(namespace, pvc string) error {
+	err := k.CoreV1().PersistentVolumeClaims(namespace).Delete(context.TODO(), pvc, metav1.DeleteOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			err = nil
+		}
+	}
+
+	return err
+}
+
+func (k *KubeClient) getPV(name string) (*corev1.PersistentVolume, error) {
+	return k.CoreV1().PersistentVolumes().Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (k *KubeClient) updatePV(pvObj *corev1.PersistentVolume) (*corev1.PersistentVolume, error) {
+	return k.CoreV1().PersistentVolumes().Update(context.TODO(), pvObj, metav1.UpdateOptions{})
+}
+
+func (k *KubeClient) deletePV(pvName string) error {
+	return k.CoreV1().PersistentVolumes().Delete(context.TODO(), pvName, metav1.DeleteOptions{})
+}
+
+func (k *KubeClient) createDeployment(deployment *appsv1.Deployment) error {
+	_, err := k.AppsV1().Deployments(deployment.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	if err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			return nil
+		}
+		return errors.Errorf("Failed to create deployment %s/%s, err=%s", deployment.Namespace, deployment.Name, err)
+	}
+	return nil
+}
+
+func (k *KubeClient) applyDeployment(deployment *appsv1.Deployment) error {
+	// TODO: Use server side apply
+	currentDeployment, err := k.AppsV1().
+		Deployments(deployment.Namespace).
+		Get(context.TODO(), deployment.Name, metav1.GetOptions{})
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			_, err := k.AppsV1().Deployments(deployment.Namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+			if err != nil {
+				return errors.Errorf("Failed to create deployment %s/%s, err=%s", deployment.Namespace, deployment.Name, err)
+			}
+		}
+		return err
+	}
+
+	data, _, err := getPatchData(currentDeployment, deployment)
+	if err != nil {
+		return err
+	}
+
+	// Patch the deployment
+	_, err = k.AppsV1().
+		Deployments(deployment.Namespace).
+		Patch(context.TODO(), deployment.Name, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+	if err != nil {
+		return err
+	}
+
+	return k.waitForDeploymentRollout(deployment.Namespace, deployment.Name)
+}
+
+func (k *KubeClient) deleteDeployment(namespace, deployment string) error {
+	return k.AppsV1().Deployments(namespace).Delete(context.TODO(), deployment, metav1.DeleteOptions{})
+}
+
+func (k *KubeClient) getDeployment(namespace, deployment string) (*appsv1.Deployment, error) {
+	return k.AppsV1().Deployments(namespace).Get(context.TODO(), deployment, metav1.GetOptions{})
+}
+
+func (k *KubeClient) updateDeployment(deployment *appsv1.Deployment) (*appsv1.Deployment, error) {
+	return k.AppsV1().Deployments(deployment.Namespace).Update(context.TODO(), deployment, metav1.UpdateOptions{})
+}
+
+func (k *KubeClient) listDeployments(namespace, labelSelector string) (*appsv1.DeploymentList, error) {
+	return k.AppsV1().Deployments(namespace).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+}
+
+func dumpK8sObject(obj runtime.Object) {
+	if encoder == nil {
+		fmt.Printf("encoder not initialized\n")
+		return
+	}
+
+	buf := new(bytes.Buffer)
+	encoder.Encode(obj, buf)
+	fmt.Println(string(buf.Bytes()))
+}
+
+func (k *KubeClient) createStorageClass(sc *storagev1.StorageClass) error {
+	_, err := k.StorageV1().StorageClasses().Create(context.TODO(), sc, metav1.CreateOptions{})
+	if err != nil {
+		if !k8serrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+func (k *KubeClient) deleteStorageClass(scName string) error {
+	return k.StorageV1().StorageClasses().Delete(context.TODO(), scName, metav1.DeleteOptions{})
+}
+
+// Add Kubernetes service related operations
+func (k *KubeClient) getService(namespace, name string) (*corev1.Service, error) {
+	return k.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func (k *KubeClient) deleteService(namespace, name string) error {
+	return k.CoreV1().Services(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+}
+
+// Add Node related operations
+func (k *KubeClient) listNodes(labelSelector string) (*corev1.NodeList, error) {
+	return k.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector})
+}
+
+func (k *KubeClient) updateNode(node *corev1.Node) (*corev1.Node, error) {
+	return k.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
+}
+
+func (k *KubeClient) getEvents(objOrRef runtime.Object) (*corev1.EventList, error) {
+	ref, err := reference.GetReference(scheme.Scheme, objOrRef)
+	if err != nil {
+		return nil, err
+	}
+	stringRefKind := string(ref.Kind)
+	var refKind *string
+	if len(stringRefKind) > 0 {
+		refKind = &stringRefKind
+	}
+	stringRefUID := string(ref.UID)
+	var refUID *string
+	if len(stringRefUID) > 0 {
+		refUID = &stringRefUID
+	}
+
+	e := k.CoreV1().Events(ref.Namespace)
+	fieldSelector := e.GetFieldSelector(&ref.Name, &ref.Namespace, refKind, refUID)
+	initialOpts := metav1.ListOptions{FieldSelector: fieldSelector.String(), Limit: defaultChunkSize}
+	eventList := &corev1.EventList{}
+	err = followContinue(&initialOpts,
+		func(options metav1.ListOptions) (runtime.Object, error) {
+			newEvents, err := e.List(context.TODO(), options)
+			if err != nil {
+				return nil, err
+			}
+			eventList.Items = append(eventList.Items, newEvents.Items...)
+			return newEvents, nil
+		})
+	return eventList, err
+}
+
+// followContinue handles the continue parameter returned
+// by the API server when using list chunking. To take
+// advantage of this, the initial ListOptions provided by
+// the consumer should include a non-zero Limit parameter.
+func followContinue(initialOpts *metav1.ListOptions,
+	listFunc func(metav1.ListOptions) (runtime.Object, error)) error {
+	opts := initialOpts
+	for {
+		list, err := listFunc(*opts)
+		if err != nil {
+			return err
+		}
+		nextContinueToken, _ := metadataAccessor.Continue(list)
+		if len(nextContinueToken) == 0 {
+			return nil
+		}
+		opts.Continue = nextContinueToken
+	}
+}
+
+func getPatchData(oldObj, newObj interface{}) ([]byte, []byte, error) {
+	oldData, err := json.Marshal(oldObj)
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal old object failed: %v", err)
+	}
+	newData, err := json.Marshal(newObj)
+	if err != nil {
+		return nil, nil, fmt.Errorf("mashal new object failed: %v", err)
+	}
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, oldObj)
+	if err != nil {
+		return nil, nil, fmt.Errorf("CreateTwoWayMergePatch failed: %v", err)
+	}
+	return patchBytes, oldData, nil
+}
+
+func (k *KubeClient) waitForDeploymentRollout(ns, deployment string) error {
+	return wait.PollInfinite(2*time.Second, func() (bool, error) {
+		deploy, err := k.AppsV1().Deployments(ns).Get(context.TODO(), deployment, metav1.GetOptions{})
+		if err != nil {
+			return true, err
+		}
+
+		var cond *appsv1.DeploymentCondition
+		// list all conditions and and select that condition which type is Progressing.
+		for i := range deploy.Status.Conditions {
+			c := deploy.Status.Conditions[i]
+			if c.Type == appsv1.DeploymentProgressing {
+				cond = &c
+			}
+		}
+		// if deploy.Generation <= deploy.Status.ObservedGeneration then deployment spec is not updated yet.
+		// it marked IsRolledout as false and update message accordingly
+		if deploy.Generation <= deploy.Status.ObservedGeneration {
+			// If Progressing condition's reason is ProgressDeadlineExceeded then it is not rolled out.
+			if cond != nil && cond.Reason == "ProgressDeadlineExceeded" {
+				return false, errors.New(fmt.Sprintf("deployment exceeded its progress deadline"))
+			}
+			// if deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas then some of the replicas are updated
+			// and some of them are not. It marked IsRolledout as false and update message accordingly
+			if deploy.Spec.Replicas != nil && deploy.Status.UpdatedReplicas < *deploy.Spec.Replicas {
+				fmt.Printf("Waiting for deployment rollout to finish: %d out of %d new replicas have been updated\n",
+					deploy.Status.UpdatedReplicas, *deploy.Spec.Replicas)
+				return false, nil
+			}
+			// if deploy.Status.Replicas > deploy.Status.UpdatedReplicas then some of the older replicas are in running state
+			// because newer replicas are not in running state. It waits for newer replica to come into running state then terminate.
+			// It marked IsRolledout as false and update message accordingly
+			if deploy.Status.Replicas > deploy.Status.UpdatedReplicas {
+				fmt.Printf("Waiting for deployment rollout to finish: %d old replicas are pending termination\n",
+					deploy.Status.Replicas-deploy.Status.UpdatedReplicas)
+				return false, nil
+			}
+			// if deploy.Status.AvailableReplicas < deploy.Status.UpdatedReplicas then all the replicas are updated but they are
+			// not in running state. It marked IsRolledout as false and update message accordingly.
+			if deploy.Status.AvailableReplicas < deploy.Status.UpdatedReplicas {
+				fmt.Printf("Waiting for deployment rollout to finish: %d of %d updated replicas are available\n",
+					deploy.Status.AvailableReplicas, deploy.Status.UpdatedReplicas)
+			}
+			return true, nil
+		}
+		fmt.Printf("Waiting for deployment spec update to be observed\n")
+		return false, nil
+	})
+}
+
+func (k *KubeClient) listEvents(namespace string) (*corev1.EventList, error) {
+	return k.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{})
+}
+
+// TODO: Move to some package where code will also use it
+
+func isFinalizerExist(metadata *metav1.ObjectMeta, expectedFinalizer string) bool {
+	for _, finalizer := range metadata.Finalizers {
+		if finalizer == expectedFinalizer {
+			return true
+		}
+	}
+	return false
+}
+
+func removeFinalizer(metadata *metav1.ObjectMeta, expectedFinalizer string) {
+	for idx, finalizer := range metadata.Finalizers {
+		if finalizer == expectedFinalizer {
+			metadata.Finalizers = append(metadata.Finalizers[:idx], metadata.Finalizers[idx+1:]...)
+			return
+		}
+	}
+	return
+}

--- a/tests/nfs/nfs_data.go
+++ b/tests/nfs/nfs_data.go
@@ -1,0 +1,237 @@
+/*
+Copyright © 2021 The MayaData Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nfs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/mayadata-io/volume-events-exporter/pkg/nfspv"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+const (
+	VolumeCreateNFSPVCKey     = "it.nfs.openebs.io/vc-nfspvc"
+	VolumeCreateNFSPVKey      = "it.nfs.openebs.io/vc-nfspv"
+	VolumeCreateBackendPVCKey = "it.nfs.openebs.io/vc-backend-pvc"
+	VolumeCreateBackendPVKey  = "it.nfs.openebs.io/vc-backend-pv"
+
+	VolumeDeleteNFSPVKey      = "it.nfs.openebs.io/vd-nfspv"
+	VolumeDeleteBackendPVCKey = "it.nfs.openebs.io/vd-backend-pvc"
+	VolumeDeleteBackendPVKey  = "it.nfs.openebs.io/vd-backend-pv"
+)
+
+type NFSCreateDeleteVolumeData struct {
+	nfspv.NFSCreateVolumeData
+	nfspv.NFSDeleteVolumeData
+}
+
+type NFS struct {
+	Clientset kubernetes.Interface
+}
+
+func (n *NFS) ProcessData(req *http.Request) error {
+	nfsData := &NFSCreateDeleteVolumeData{}
+	err := decodeBody(req, nfsData)
+	if err != nil {
+		return errors.Wrapf(err, "decode of data failed")
+	}
+
+	if nfsData.VolumeProvisioned != nil {
+		err = n.processProvisionedNFSData(nfsData.VolumeProvisioned)
+		if err != nil {
+			return err
+		}
+	}
+	if nfsData.VolumeDeleted != nil {
+		err = n.processDeProvisionedNFSData(nfsData.VolumeDeleted)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// processProvisionedNFSData will process the data received over network and
+// add followend annotation to backend pvc which is later used to verify in Integration test
+// - it.nfs.openebs.io/vc-nfspvc: <nfspvc-ns>-<nfspvc-name>
+// - it.nfs.openebs.io/vc-nfspv: <nfs-pv-name>
+// - it.nfs.openebs.io/vc-backend-pvc: <backend-pvc>-<backend-pvc-name>
+// - it.nfs.openebs.io/vc-backend-pv: <backend-pv-name>
+// NOTE:
+//	- Kubernetes doesn't allow to add new finalizers when object is marked for deletion
+//	  so adding all the details on backend pvc annotation.
+//	- Backend PVC will also add integration test finalizer {it.openebs.io/test-verification}
+//	  during provisioning time which will get removed after after verifying from Integration test
+func (n *NFS) processProvisionedNFSData(nfsVolumeData *nfspv.NFSVolumeData) error {
+	isNFSPVExist := nfsVolumeData.NFSPV != nil
+	isBackendPVCExist := nfsVolumeData.BackingPVC != nil
+	isBackendPVExist := nfsVolumeData.BackingPV != nil
+	// All(nfspv, backend pvc, backend pv) data should exist
+	if !isNFSPVExist || !isBackendPVCExist || !isBackendPVExist {
+		return errors.Errorf("expected to have NFS PV(%t), Backend PVC(%t) and Backend PV(%t) to exist", isNFSPVExist, isBackendPVCExist, isBackendPVExist)
+	}
+	testAnnotations := map[string]string{}
+
+	if nfsVolumeData.NFSPVC != nil {
+		testAnnotations[VolumeCreateNFSPVCKey] = nfsVolumeData.NFSPVC.Namespace + "-" + nfsVolumeData.NFSPVC.Name
+	}
+
+	if nfsVolumeData.NFSPV.CreationTimestamp.IsZero() {
+		return errors.Errorf("expected to have creation timestamp on NFS PV %s", nfsVolumeData.NFSPV.Name)
+	}
+	testAnnotations[VolumeCreateNFSPVKey] = nfsVolumeData.NFSPV.Name
+	testAnnotations[VolumeCreateBackendPVCKey] = nfsVolumeData.BackingPVC.Namespace + "-" + nfsVolumeData.BackingPVC.Name
+	testAnnotations[VolumeCreateBackendPVKey] = nfsVolumeData.BackingPV.Name
+
+	if nfsVolumeData.BackingPVC.Annotations == nil {
+		nfsVolumeData.BackingPVC.Annotations = map[string]string{}
+	}
+	for key, value := range testAnnotations {
+		nfsVolumeData.BackingPVC.Annotations[key] = value
+	}
+
+	_, err := n.Clientset.CoreV1().
+		PersistentVolumeClaims(nfsVolumeData.BackingPVC.Namespace).
+		Update(context.TODO(), nfsVolumeData.BackingPVC, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	klog.Infof("Addedd annotations %v on backend pvc %s/%s for create event", testAnnotations, nfsVolumeData.BackingPVC.Namespace, nfsVolumeData.BackingPVC.Name)
+	return nil
+}
+
+// processDeProvisionedNFSData will process the data received over network and
+// add following annotation to backend pvc which is later used to verify in Integration test
+// - it.nfs.openebs.io/vd-nfspvc: <nfspvc-ns>-<nfspvc-name>
+// - it.nfs.openebs.io/vd-nfspv: <nfs-pv-name>
+// - it.nfs.openebs.io/vd-backend-pvc: <backend-pvc>-<backend-pvc-name>
+// - it.nfs.openebs.io/vd-backend-pv: <backend-pv-name>
+// NOTE:
+//	- Kubernetes doesn't allow to add new finalizers when object is marked for deletion
+//	  so adding all the details on backend pvc annotation.
+//	- Backend PVC will also add integration test finalizer {it.openebs.io/test-verification}
+//	  during provisioning time which will get removed after after verifying from Integration test
+func (n *NFS) processDeProvisionedNFSData(nfsVolumeData *nfspv.NFSVolumeData) error {
+	isNFSPVExist := nfsVolumeData.NFSPV != nil
+	isBackendPVCExist := nfsVolumeData.BackingPVC != nil
+	isBackendPVExist := nfsVolumeData.BackingPV != nil
+	// All(nfspv, backend pvc, backend pv) data should exist
+	if !isNFSPVExist || !isBackendPVCExist || !isBackendPVExist {
+		return errors.Errorf("expected to have NFS PV(%t), Backend PVC(%t) and Backend PV(%t) to exist", isNFSPVExist, isBackendPVCExist, isBackendPVExist)
+	}
+
+	if nfsVolumeData.NFSPV.CreationTimestamp.IsZero() {
+		return errors.Errorf("expected to have creation timestamp on NFS PV %s", nfsVolumeData.NFSPV.Name)
+	}
+
+	if nfsVolumeData.NFSPV.DeletionTimestamp.IsZero() {
+		return errors.Errorf("expected to have deletion timestamp on NFS PV %s", nfsVolumeData.NFSPV.Name)
+	}
+
+	testAnnotations := map[string]string{
+		VolumeDeleteNFSPVKey:      nfsVolumeData.NFSPV.Name,
+		VolumeDeleteBackendPVCKey: nfsVolumeData.BackingPVC.Namespace + "-" + nfsVolumeData.BackingPVC.Name,
+		VolumeDeleteBackendPVKey:  nfsVolumeData.BackingPV.Name,
+	}
+
+	if nfsVolumeData.BackingPVC.Annotations == nil {
+		nfsVolumeData.BackingPVC.Annotations = map[string]string{}
+	}
+	for key, value := range testAnnotations {
+		nfsVolumeData.BackingPVC.Annotations[key] = value
+	}
+
+	_, err := n.Clientset.CoreV1().
+		PersistentVolumeClaims(nfsVolumeData.BackingPVC.Namespace).
+		Update(context.TODO(), nfsVolumeData.BackingPVC, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	klog.Infof("Addedd annotations %v on backend pvc %s/%s for create event", testAnnotations, nfsVolumeData.BackingPVC.Namespace, nfsVolumeData.BackingPVC.Name)
+
+	return nil
+}
+
+// func (n *NFS) updatePVCWithFinalizer(pvcObj *corev1.PersistentVolumeClaim, finalizer string) error {
+// 	for _, f := range pvcObj.Finalizers {
+// 		if f == finalizer {
+// 			return nil
+// 		}
+// 	}
+//
+// 	pvcObj.Finalizers = append(pvcObj.Finalizers, finalizer)
+// 	_, err := n.Clientset.CoreV1().
+// 		PersistentVolumeClaims(pvcObj.Namespace).
+// 		Update(context.TODO(), pvcObj, metav1.UpdateOptions{})
+// 	return err
+// }
+//
+// func (n *NFS) updatePVWithFinalizer(pvObj *corev1.PersistentVolume, finalizer string) error {
+// 	for _, f := range pvObj.Finalizers {
+// 		if f == finalizer {
+// 			return nil
+// 		}
+// 	}
+// 	pvObj.Finalizers = append(pvObj.Finalizers, finalizer)
+// 	_, err := n.Clientset.CoreV1().
+// 		PersistentVolumes().
+// 		Update(context.TODO(), pvObj, metav1.UpdateOptions{})
+// 	return err
+// }
+
+// TODO: Move below function to some common package
+
+// getContentType will return data type by looking at Header
+func getContentType(req *http.Request) (string, error) {
+
+	if req.Header == nil {
+		return "", fmt.Errorf("Request does not have any header")
+	}
+
+	return req.Header.Get("Content-Type"), nil
+}
+
+// Decode the request body to appropriate structure based on content type
+func decodeBody(req *http.Request, out interface{}) error {
+
+	cType, err := getContentType(req)
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(cType, "yaml") {
+		return errors.Errorf("expecting JSON based content type")
+	}
+
+	// default is assumed to be json content
+	return decodeJsonBody(req, out)
+}
+
+// decodeJsonBody is used to decode a JSON request body
+func decodeJsonBody(req *http.Request, out interface{}) error {
+	dec := json.NewDecoder(req.Body)
+	return dec.Decode(&out)
+}

--- a/tests/nfs_sanity_test.go
+++ b/tests/nfs_sanity_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2021 The MayaData Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tests
 
 import (

--- a/tests/nfs_sanity_test.go
+++ b/tests/nfs_sanity_test.go
@@ -249,34 +249,3 @@ func markNFSResources(nfsPVCNamespace, nfsPVCName string) error {
 	}
 	return nil
 }
-
-// nfsPVObj, err := Client.getPV(nfsPVCObj.Spec.VolumeName)
-// Expect(err).To(BeNil(), "while fetching NFS pv %s", nfsPVCObj.Spec.VolumeName)
-// Expect(isFinalizerExist(&nfsPVObj.ObjectMeta, nfs.ProvisionedFinalizerProtection)).To(BeTrue(), "NFS pv %s details are not exported to server for create event")
-
-// nfsPVName = nfsPVObj.Name
-// backendPVCName = "nfs-" + nfsPVName
-// backendPVC, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
-// Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
-// Expect(isFinalizerExist(&backendPVC.ObjectMeta, nfs.ProvisionedFinalizerProtection)).To(BeTrue(), "backend pvc %s/%s details are not exported to server for create event", OpenEBSNamespace, backendPVCName)
-
-// backendPVName = backendPVC.Spec.VolumeName
-// backendPVObj, err := Client.getPV(backendPVC.Spec.VolumeName)
-// Expect(err).To(BeNil(), "while fetching backend pv %s", backendPVC.Spec.VolumeName)
-// Expect(isFinalizerExist(&backendPVObj.ObjectMeta, nfs.ProvisionedFinalizerProtection)).To(BeTrue(), "backend pv %s details are not exported to server for create event", backendPVObj.Name)
-
-// // Remove event finalizers on backend PVC
-// backendPVC, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
-// Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
-// removeFinalizer(&backendPVC.ObjectMeta, nfs.ProvisionedFinalizerProtection)
-// removeFinalizer(&backendPVC.ObjectMeta, nfs.DeProvisionedFinalizerProtection)
-// _, err = Client.updatePVC(backendPVC)
-// Expect(err).To(BeNil(), "while removing event finalizers on backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
-
-// // Remove event finalizer on backend PV
-// backendPV, err := Client.getPV(backendPVName)
-// Expect(err).To(BeNil(), "while fetching NFS pv %s", backendPVName)
-// removeFinalizer(&backendPV.ObjectMeta, nfs.ProvisionedFinalizerProtection)
-// removeFinalizer(&backendPV.ObjectMeta, nfs.DeProvisionedFinalizerProtection)
-// _, err = Client.updatePV(backendPV)
-// Expect(err).To(BeNil(), "while removing event finalzers on backend pv %s", backendPVName)

--- a/tests/nfs_sanity_test.go
+++ b/tests/nfs_sanity_test.go
@@ -70,6 +70,7 @@ var _ = Describe("TEST NFS PVC CREATE & DELTE EVENTS", func() {
 			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
 			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
 
+			// TODO: Remove below lines after merging https://github.com/openebs/dynamic-nfs-provisioner/pull/97 PR
 			err = markNFSResources(applicationNamespace, pvcName)
 			Expect(err).To(BeNil(), "while makrking for events")
 		})

--- a/tests/nfs_sanity_test.go
+++ b/tests/nfs_sanity_test.go
@@ -1,0 +1,266 @@
+package tests
+
+import (
+	"time"
+
+	"github.com/mayadata-io/volume-events-exporter/tests/nfs"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("TEST NFS PVC CREATE & DELTE EVENTS", func() {
+	var (
+		// PVC configuration
+		accessModes    = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany}
+		capacity       = "1Gi"
+		pvcName        = "sanity-event-nfs-pvc"
+		scName         = "openebs-rwx"
+		nfsPVName      string
+		backendPVCName string
+		backendPVName  string
+
+		// backend pvc configuration
+		integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
+
+		maxRetryCount = 15
+	)
+
+	When("pvc with storageclass openebs-rwx is created", func() {
+		It("should create a pvc ", func() {
+			By("creating above pvc")
+			err := Client.createPVC(&corev1.PersistentVolumeClaim{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pvcName,
+					Namespace: applicationNamespace,
+				},
+				Spec: corev1.PersistentVolumeClaimSpec{
+					StorageClassName: &scName,
+					AccessModes:      accessModes,
+					Resources: corev1.ResourceRequirements{
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							corev1.ResourceStorage: resource.MustParse(capacity),
+						},
+					},
+				},
+			})
+			Expect(err).To(BeNil(), "while creating pvc {%s} in namespace {%s}", pvcName, applicationNamespace)
+
+			pvcPhase, err := Client.waitForPVCBound(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
+			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
+
+			err = markNFSResources(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while makrking for events")
+		})
+	})
+
+	When("pvc gets into bounded state", func() {
+		It("should have NFS server in running state", func() {
+			pvcObj, err := Client.getPVC(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while fetching pvc %s/%s", applicationNamespace, pvcName)
+			nfsPVName = pvcObj.Spec.VolumeName
+			// NOTE: Backend PVC name will be nfs-<nfs pv name>
+			backendPVCName = "nfs-" + nfsPVName
+
+			nfsServerLabelSelector := "openebs.io/nfs-server=nfs-" + pvcObj.Spec.VolumeName
+			err = Client.waitForPods(OpenEBSNamespace, nfsServerLabelSelector, corev1.PodRunning, 1)
+			Expect(err).To(BeNil(), "while verifying NFS Server running status")
+		})
+
+		It("should have sent details to server... verify annotation of backing PVC", func() {
+			var backingPVCObj *corev1.PersistentVolumeClaim
+			var err error
+			var isEventReceived bool
+
+			for retries := 0; retries < maxRetryCount; retries++ {
+				backingPVCObj, err = Client.getPVC(OpenEBSNamespace, backendPVCName)
+				Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+
+				_, isEventReceived = backingPVCObj.Annotations[nfs.VolumeCreateNFSPVCKey]
+				if isEventReceived {
+					break
+				}
+				// Reconciliation will happen at every 60 seconds but if any error occurs it will
+				// get reconcile easily
+				time.Sleep(time.Second * 10)
+			}
+			Expect(isEventReceived).To(BeTrue(), "NFS pvc %s/%s details are not exported to server", applicationNamespace, pvcName)
+			backendPVC, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
+			Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+			backendPVName = backendPVC.Spec.VolumeName
+
+			Expect(backingPVCObj.Annotations[nfs.VolumeCreateNFSPVCKey]).To(Equal(applicationNamespace+"-"+pvcName), "while verifying nfs pvc create event data")
+			Expect(backingPVCObj.Annotations[nfs.VolumeCreateNFSPVKey]).To(Equal(nfsPVName), "while verifying nfs pv create event data")
+			Expect(backingPVCObj.Annotations[nfs.VolumeCreateBackendPVCKey]).To(Equal(OpenEBSNamespace+"-"+backendPVCName), "while verifying backend pvc create event data")
+			Expect(backingPVCObj.Annotations[nfs.VolumeCreateBackendPVKey]).To(Equal(backendPVName), "while verifying backend pv create event data")
+		})
+	})
+
+	When("pvc is deleted", func() {
+		It("should delete pvc", func() {
+			err := Client.deletePVC(applicationNamespace, pvcName)
+			Expect(err).To(BeNil(), "while deleting pvc %s/%s", applicationNamespace, pvcName)
+		})
+
+		It("should send events to server", func() {
+			var backingPVCObj *corev1.PersistentVolumeClaim
+			var err error
+			var isEventReceived bool
+
+			for retry := 0; retry < maxRetryCount; retry++ {
+				backingPVCObj, err = Client.getPVC(OpenEBSNamespace, backendPVCName)
+				Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+
+				_, isEventReceived = backingPVCObj.Annotations[nfs.VolumeDeleteNFSPVKey]
+				if isEventReceived {
+					break
+				}
+				// Reconciliation will happen at every 60 seconds but if any error occurs it will
+				// get reconcile easily
+				time.Sleep(time.Second * 10)
+			}
+			Expect(isEventReceived).To(BeTrue(), "NFS pv %s details are not exported to server for delete event", nfsPVName)
+			Expect(backingPVCObj.Annotations[nfs.VolumeDeleteNFSPVKey]).To(Equal(nfsPVName), "while verifying NFS pv delete event data")
+			Expect(backingPVCObj.Annotations[nfs.VolumeDeleteBackendPVCKey]).To(Equal(OpenEBSNamespace+"-"+backendPVCName), "while verifying backend pvc delete event data")
+			Expect(backingPVCObj.Annotations[nfs.VolumeDeleteBackendPVKey]).To(Equal(backendPVName), "while verifying backend pv delete event data")
+		})
+	})
+
+	When("test event finalizers are removed on resource", func() {
+		It("should get removed", func() {
+			// Remove test finalizer on Backend PVC
+			backendPVC, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
+			Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+			removeFinalizer(&backendPVC.ObjectMeta, integrationTestFinalizer)
+			_, err = Client.updatePVC(backendPVC)
+			Expect(err).To(BeNil(), "while removing test protection finalizer on backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+
+		})
+
+		It("should get deleted from cluster", func() {
+
+			// Check NFS PV existence
+			var isNFSPVExist bool = true
+			for retry := 0; retry < maxRetryCount; retry++ {
+				_, err := Client.getPV(nfsPVName)
+				if err != nil && k8serrors.IsNotFound(err) {
+					isNFSPVExist = false
+					break
+				}
+				Expect(err).To(BeNil(), "while checking for existence of NFS pv %s", nfsPVName)
+				time.Sleep(time.Second * 10)
+			}
+			Expect(isNFSPVExist).To(BeFalse(), "NFS pv %s shouldn't exist in cluster", nfsPVName)
+
+			// Check backend PVC existence
+			var isBackendPVCExist bool = true
+			for retry := 0; retry < maxRetryCount; retry++ {
+				_, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
+				if err != nil && k8serrors.IsNotFound(err) {
+					isBackendPVCExist = false
+					break
+				}
+				Expect(err).To(BeNil(), "while checking for existence of backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+				time.Sleep(time.Second * 10)
+			}
+			Expect(isBackendPVCExist).To(BeFalse(), "backend pvc %s/%s shouldn't exist in cluster", OpenEBSNamespace, backendPVCName)
+
+			// Check backend PV existence
+			var isBackendPVExist bool = true
+			for retry := 0; retry < maxRetryCount; retry++ {
+				_, err := Client.getPV(backendPVName)
+				if err != nil && k8serrors.IsNotFound(err) {
+					isBackendPVExist = false
+					break
+				}
+				Expect(err).To(BeNil(), "while checking for existence of backend pv %s", backendPVName)
+				time.Sleep(time.Second * 10)
+			}
+			Expect(isBackendPVExist).To(BeFalse(), "backend pv %s shouldn't exist in cluster", OpenEBSNamespace, backendPVName)
+		})
+	})
+})
+
+// This function can be removed once configmap support is merged for
+// configuring metadata on NFS provisioner owned resources
+func markNFSResources(nfsPVCNamespace, nfsPVCName string) error {
+	nfsEventFinalizer := "nfs.events.openebs.io/finalizer"
+	integrationTestFinalizer := "it.nfs.openebs.io/test-protection"
+	nfsPVC, err := Client.getPVC(nfsPVCNamespace, nfsPVCName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch PVC %s/%s", nfsPVCNamespace, nfsPVCName)
+	}
+
+	nfsPV, err := Client.getPV(nfsPVC.Spec.VolumeName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch NFS pv %s", nfsPVC.Spec.VolumeName)
+	}
+
+	backendPVCName := "nfs-" + nfsPVC.Spec.VolumeName
+	backendPVC, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+	}
+	backendPVC.Finalizers = append(backendPVC.Finalizers, nfsEventFinalizer, integrationTestFinalizer)
+	_, err = Client.updatePVC(backendPVC)
+	if err != nil {
+		return errors.Wrapf(err, "while adding event finalzers on NFS pv %s", backendPVCName)
+	}
+
+	backendPV, err := Client.getPV(backendPVC.Spec.VolumeName)
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch backend pv %s", backendPVC.Spec.VolumeName)
+	}
+	backendPV.Finalizers = append(backendPV.Finalizers, nfsEventFinalizer)
+	_, err = Client.updatePV(backendPV)
+	if err != nil {
+		return errors.Wrapf(err, "while adding event finalizers on backend pv %s", backendPV.Name)
+	}
+
+	nfsPV.Finalizers = append(nfsPV.Finalizers, nfsEventFinalizer)
+	if nfsPV.Annotations == nil {
+		nfsPV.Annotations = map[string]string{}
+	}
+	nfsPV.Annotations["events.openebs.io/required"] = "true"
+	_, err = Client.updatePV(nfsPV)
+	if err != nil {
+		return errors.Wrapf(err, "while adding event finalizers on NFS pvc %s/%s", nfsPV.Namespace, nfsPV.Name)
+	}
+	return nil
+}
+
+// nfsPVObj, err := Client.getPV(nfsPVCObj.Spec.VolumeName)
+// Expect(err).To(BeNil(), "while fetching NFS pv %s", nfsPVCObj.Spec.VolumeName)
+// Expect(isFinalizerExist(&nfsPVObj.ObjectMeta, nfs.ProvisionedFinalizerProtection)).To(BeTrue(), "NFS pv %s details are not exported to server for create event")
+
+// nfsPVName = nfsPVObj.Name
+// backendPVCName = "nfs-" + nfsPVName
+// backendPVC, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
+// Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+// Expect(isFinalizerExist(&backendPVC.ObjectMeta, nfs.ProvisionedFinalizerProtection)).To(BeTrue(), "backend pvc %s/%s details are not exported to server for create event", OpenEBSNamespace, backendPVCName)
+
+// backendPVName = backendPVC.Spec.VolumeName
+// backendPVObj, err := Client.getPV(backendPVC.Spec.VolumeName)
+// Expect(err).To(BeNil(), "while fetching backend pv %s", backendPVC.Spec.VolumeName)
+// Expect(isFinalizerExist(&backendPVObj.ObjectMeta, nfs.ProvisionedFinalizerProtection)).To(BeTrue(), "backend pv %s details are not exported to server for create event", backendPVObj.Name)
+
+// // Remove event finalizers on backend PVC
+// backendPVC, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
+// Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+// removeFinalizer(&backendPVC.ObjectMeta, nfs.ProvisionedFinalizerProtection)
+// removeFinalizer(&backendPVC.ObjectMeta, nfs.DeProvisionedFinalizerProtection)
+// _, err = Client.updatePVC(backendPVC)
+// Expect(err).To(BeNil(), "while removing event finalizers on backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
+
+// // Remove event finalizer on backend PV
+// backendPV, err := Client.getPV(backendPVName)
+// Expect(err).To(BeNil(), "while fetching NFS pv %s", backendPVName)
+// removeFinalizer(&backendPV.ObjectMeta, nfs.ProvisionedFinalizerProtection)
+// removeFinalizer(&backendPV.ObjectMeta, nfs.DeProvisionedFinalizerProtection)
+// _, err = Client.updatePV(backendPV)
+// Expect(err).To(BeNil(), "while removing event finalzers on backend pv %s", backendPVName)

--- a/tests/server/rest/rest_server.go
+++ b/tests/server/rest/rest_server.go
@@ -1,0 +1,133 @@
+/*
+Copyright © 2021 The MayaData Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"net/http"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/gorilla/mux"
+	"github.com/mayadata-io/volume-events-exporter/tests/server"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+)
+
+// ServerConfig will instantiate the new rest server
+type ServerConfig struct {
+
+	// IPAddress holds address of the REST server
+	IPAddress string
+
+	// Port holds the port number on which server needs to run
+	Port int
+
+	// SecreteKey defines the secret key to communicate with the server
+	SecretKey string
+
+	// TLSTimeout defines the timeout expiry timeout of generated token
+	TLSTimeout time.Duration
+
+	// Clientset is used to interact with Kube-APIServer
+	Clientset kubernetes.Interface
+
+	// EventsReceiver to process events
+	EventsReceiver server.EventsReceiver
+}
+
+type restServer struct {
+	service *service
+	// token will be generated and stored in-memory and it can be used
+	// if integration test case required to interact with server
+	token string
+}
+
+func NewRestServer(config ServerConfig) (server.ServerInterface, error) {
+	token, err := getToken(config.SecretKey, config.TLSTimeout)
+	if err != nil {
+		return nil, err
+	}
+	r := &restServer{
+		service: &service{
+			clientset: config.Clientset,
+			httpServer: &http.Server{
+				Addr: config.IPAddress + ":" + strconv.Itoa(config.Port),
+			},
+			secretKey:     config.SecretKey,
+			dataProcessor: config.EventsReceiver,
+		},
+		token: token,
+	}
+
+	router := mux.NewRouter().StrictSlash(true)
+	router.Handle("/event-server", r.service.isAuthorized(r.service.eventsHandler)).Methods("POST")
+	r.service.httpServer.Handler = router
+
+	return r, nil
+}
+
+// Start will start the REST Service
+// as various endpoints to acknowledge data
+// NOTE: Stop must be called after shuting down the node
+func (r *restServer) Start() error {
+	go func() {
+		err := r.service.httpServer.ListenAndServe()
+		if err != nil {
+			klog.Warningf("error: %s", err.Error())
+			return
+		}
+	}()
+	return nil
+}
+
+// Stop will stop the running service by calling
+// shutdown. If there are no active listeners
+// call will be returned immediately else it
+// will take 1minute to return
+func (r *restServer) Stop() error {
+	ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
+	defer cancel()
+	return r.service.httpServer.Shutdown(ctx)
+}
+
+// GetToken will return the token required that is required
+// to interact with the server
+func (r *restServer) GetToken() string {
+	return r.token
+}
+
+func (r *restServer) GetEventsReceiverEndpoint() string {
+	return "http://" + r.service.httpServer.Addr + "/event-server"
+}
+
+func getToken(secretKey string, tlsTimeout time.Duration) (string, error) {
+	token := jwt.New(jwt.SigningMethodHS256)
+	claims := token.Claims.(jwt.MapClaims)
+
+	claims["authorized"] = true
+	claims["user"] = "rest service"
+	claims["exp"] = time.Now().Add(tlsTimeout).Unix()
+	tokenString, err := token.SignedString([]byte(secretKey))
+	if err != nil {
+		return "", errors.Wrapf(err, "something went wrong")
+	}
+	return tokenString, nil
+}

--- a/tests/server/rest/service.go
+++ b/tests/server/rest/service.go
@@ -1,0 +1,95 @@
+/*
+Copyright © 2021 The MayaData Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/mayadata-io/volume-events-exporter/tests/server"
+	"github.com/pkg/errors"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog"
+)
+
+// Service implements the endpoints that are
+// required to full fill the integration test needs.
+//
+// Endpoints:-
+// event-server(eventsHandler): Endpoint which will receives the volume create and
+//				 delete events. When events are received service will
+//				 update the respective CR's with finalizer{it.openebs.io/volume-create-protection,
+//				 it.openebs.io/volume-destroy-protection}. This finalizer on
+//				 CR's ensure that REST service received the request.
+//				 TODO: Do we need to received data in-memory?
+
+type service struct {
+	clientset     kubernetes.Interface
+	httpServer    *http.Server
+	secretKey     string
+	dataProcessor server.EventsReceiver
+}
+
+type volumeDataType string
+
+const (
+	nfsDataType volumeDataType = "NFSDataType"
+)
+
+// isAuthorized is a token based authentication check that client should pass the token in request Header
+func (s *service) isAuthorized(endpointHandler func(http.ResponseWriter, *http.Request)) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header["Token"] != nil {
+			token, err := jwt.Parse(r.Header["Token"][0], func(token *jwt.Token) (interface{}, error) {
+				if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+					return nil, errors.Errorf("Unable to authorize")
+				}
+				return []byte(s.secretKey), nil
+			})
+			if err != nil {
+				fmt.Fprintf(w, fmt.Sprintf("Failed to parse token error: %s", err.Error()))
+			}
+
+			if token.Valid {
+				endpointHandler(w, r)
+			}
+		} else {
+			fmt.Fprintf(w, "UnAuthorized!! Access Denied")
+		}
+	})
+}
+
+func (s *service) eventsHandler(resp http.ResponseWriter, req *http.Request) {
+	var httpCode int
+	var message string
+
+	klog.Infof("Received event handler event to process data")
+	err := s.dataProcessor.ProcessData(req)
+	if err != nil {
+		httpCode = 500
+		message = errors.Wrapf(err, "failed to process data").Error()
+		resp.WriteHeader(httpCode)
+		resp.Write([]byte(message))
+		return
+	}
+	httpCode = 200
+	message = "Ok"
+	resp.WriteHeader(httpCode)
+	resp.Write([]byte(message))
+	return
+}

--- a/tests/server/server.go
+++ b/tests/server/server.go
@@ -1,0 +1,45 @@
+/*
+Copyright © 2021 The MayaData Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import "net/http"
+
+// ServerInterface holds methods which are required to operate server
+// ex: gRPC, REST
+type ServerInterface interface {
+	// Start will run the server in a GO routine and return
+	// an error if occurs any
+	Start() error
+
+	// Stop will shutdown running server and return an error
+	// if occurs any
+	Stop() error
+
+	// Get token will return an valid token which is used to
+	// interact with server
+	GetToken() string
+
+	// GetEventsReceiverEndpoint will return endpoint where
+	// server is serving the request
+	GetEventsReceiverEndpoint() string
+}
+
+// EventReceiver holds a method which will be triggered upon
+// receiving a request from the client(over endpoints)
+type EventsReceiver interface {
+	ProcessData(req *http.Request) error
+}

--- a/tests/server/server.go
+++ b/tests/server/server.go
@@ -29,7 +29,7 @@ type ServerInterface interface {
 	// if occurs any
 	Stop() error
 
-	// Get token will return an valid token which is used to
+	// GetToken will return an valid token which is used to
 	// interact with server
 	GetToken() string
 

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright © 2021 The MayaData Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package tests
 
 import (

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -1,0 +1,226 @@
+package tests
+
+import (
+	"flag"
+	"fmt"
+	"net"
+	"time"
+
+	"os"
+	"testing"
+
+	"github.com/mayadata-io/volume-events-exporter/tests/nfs"
+	"github.com/mayadata-io/volume-events-exporter/tests/server"
+	"github.com/mayadata-io/volume-events-exporter/tests/server/rest"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	// auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var (
+	// CLI options
+	kubeConfigPath string
+	ipAddress      string
+	port           int
+	serverType     string
+
+	serverIface server.ServerInterface
+
+	// Artifacts required configuration
+	applicationNamespace        = "event-exporter-tests-ns"
+	nfsProvisionerName          = "openebs-nfs-provisioner"
+	nfsProvisionerLabelSelector = "openebs.io/component-name=openebs-nfs-provisioner"
+	OpenEBSNamespace            = "openebs"
+)
+
+func TestSource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test application deployment")
+}
+
+func init() {
+	flag.StringVar(&kubeConfigPath, "kubeconfig", os.Getenv("KUBECONFIG"), "path to kubeconfig to invoke kubernetes API calls")
+	flag.StringVar(&ipAddress, "address", "", "address on which server will start. Defaults to machine IP Address")
+	flag.IntVar(&port, "port", 9090, "port on which server will listen. Defaults to 9090")
+	flag.StringVar(&serverType, "type", "rest", "type of the server to serve service. Supported only REST")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+	flag.Parse()
+
+	if err := initK8sClient(kubeConfigPath); err != nil {
+		panic(fmt.Sprintf("failed to initialize k8s client err=%s", err))
+	}
+	if ipAddress == "" {
+		ipAddress, err = externalIP()
+		if err != nil {
+			panic(fmt.Sprintf("failed to get externalIP address, err: %s", err))
+		}
+	}
+
+	serverIface, err = newServer(ipAddress, port, serverType)
+	Expect(err).To(BeNil(), "while instantiating the new server")
+	err = serverIface.Start()
+	Expect(err).To(BeNil(), "while starting the server")
+
+	By("waiting for openebs-nfs-provisioner pod to come into running state")
+	err = Client.waitForPods(OpenEBSNamespace, nfsProvisionerLabelSelector, corev1.PodRunning, 1)
+	Expect(err).To(BeNil(), "while waiting for nfs deployment to be ready")
+
+	err = addEventControllerSideCar(OpenEBSNamespace, nfsProvisionerName)
+	Expect(err).To(BeNil(), "while adding volume-event-exporter sidecar")
+
+	By("building a namespace")
+	err = Client.createNamespace(applicationNamespace)
+	Expect(err).To(BeNil(), "while creating namespace {%s}", applicationNamespace)
+})
+
+var _ = AfterSuite(func() {
+	if Client != nil {
+		By("deleting namespace")
+		err := Client.destroyNamespace(applicationNamespace)
+		Expect(err).To(BeNil(), "while deleting namespace {%s}", applicationNamespace)
+	}
+	if serverIface != nil {
+		err := serverIface.Stop()
+		Expect(err).To(BeNil(), "while stopping the server")
+	}
+
+})
+
+func newServer(address string, port int, serverType string) (server.ServerInterface, error) {
+	switch serverType {
+	case "rest":
+		return rest.NewRestServer(rest.ServerConfig{
+			IPAddress:  address,
+			Port:       port,
+			SecretKey:  "mayadata-io-secret",
+			TLSTimeout: 2 * time.Hour,
+			Clientset:  Client.Interface,
+			EventsReceiver: &nfs.NFS{
+				Clientset: Client.Interface,
+			},
+		})
+	}
+	return nil, errors.Errorf("Unsupported server type %s", serverType)
+}
+
+// addOrUpdateEventControllerSidecar will add volume-event-controller side car only
+// if container doesn't exist else updates the CALLBACK_URL and CALLBACK_TOKEN
+func addEventControllerSideCar(deploymentNamespace, deploymentName string) error {
+	deployObj, err := Client.getDeployment(deploymentNamespace, deploymentName)
+	if err != nil {
+		return err
+	}
+	var isVolumeEventsCollectorExist bool
+	volumeEventsCollector := corev1.Container{
+		Name:  "volume-events-collector",
+		Image: "mayadataio/volume-events-exporter:ci",
+		Args: []string{
+			"--leader-election=false",
+			"--generate-k8s-events=true",
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name:  "OPENEBS_IO_NFS_SERVER_NS",
+				Value: OpenEBSNamespace,
+			},
+			{
+				Name:  "CALLBACK_URL",
+				Value: serverIface.GetEventsReceiverEndpoint(),
+			},
+			{
+				Name:  "CALLBACK_TOKEN",
+				Value: serverIface.GetToken(),
+			},
+		},
+	}
+
+	for idx, container := range deployObj.Spec.Template.Spec.Containers {
+		if container.Name == volumeEventsCollector.Name {
+			deployObj.Spec.Template.Spec.Containers[idx] = volumeEventsCollector
+			isVolumeEventsCollectorExist = true
+			break
+		}
+	}
+	if !isVolumeEventsCollectorExist {
+		deployObj.Spec.Template.Spec.Containers = append(deployObj.Spec.Template.Spec.Containers, volumeEventsCollector)
+	}
+	updatedDeployObj, err := Client.updateDeployment(deployObj)
+	if err != nil {
+		return err
+	}
+	return Client.waitForDeploymentRollout(updatedDeployObj.Namespace, updatedDeployObj.Name)
+}
+
+func removeEventsCollectorSidecar(deploymentNamespace, deploymentName string) error {
+	var isVolumeEventsCollectorExist bool
+	var index int
+
+	deployObj, err := Client.getDeployment(deploymentNamespace, deploymentName)
+	if err != nil {
+		return err
+	}
+
+	for idx, container := range deployObj.Spec.Template.Spec.Containers {
+		if container.Name == "volume-events-collector" {
+			index = idx
+			isVolumeEventsCollectorExist = true
+		}
+	}
+	// Remove volume events collector sidecar
+	if !isVolumeEventsCollectorExist {
+		return nil
+	}
+
+	deployObj.Spec.Template.Spec.Containers = append(deployObj.Spec.Template.Spec.Containers[:index], deployObj.Spec.Template.Spec.Containers[index+1:]...)
+	updatedDeployObj, err := Client.updateDeployment(deployObj)
+	if err != nil {
+		return err
+	}
+	return Client.waitForDeploymentRollout(updatedDeployObj.Namespace, updatedDeployObj.Name)
+}
+
+// externalIP will fetch the IP from ifconfig
+func externalIP() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue // interface down
+		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue // loopback interface
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			return "", err
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			ip = ip.To4()
+			if ip == nil {
+				continue // not an ipv4 address
+			}
+			return ip.String(), nil
+		}
+	}
+	return "", errors.New("are you connected to the network?")
+}

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -61,7 +61,7 @@ func TestSource(t *testing.T) {
 
 func init() {
 	flag.StringVar(&kubeConfigPath, "kubeconfig", os.Getenv("KUBECONFIG"), "path to kubeconfig to invoke kubernetes API calls")
-	flag.StringVar(&ipAddress, "address", "", "address on which server will start. Defaults to machine IP Address")
+	flag.StringVar(&ipAddress, "address", "", "address on which server(event listener) will start. Defaults to machine IP Address")
 	flag.IntVar(&port, "port", 9090, "port on which server will listen. Defaults to 9090")
 	flag.StringVar(&serverType, "type", "rest", "type of the server to serve service. Supported only REST")
 }


### PR DESCRIPTION
**What This PR does?**
This PR adds a sanity test to verify volume-event-exporter behavior
during NFS PVC creates and deletes events. When volume-event-exporter
sends events to the server, event server will add annotation of NFS PVC
namespace & name, NFS PV, backend PVC namespace & name, backend PV name
on backend PVC during create & delete event. Later those annotations
will be verified by an integration test.

**Note**:
- To run the integration test clone the repository and run `make sanity-test`.
- Integration test will start REST server and stop the server when test ends.

**Note to reviewers**:
- Integration test related code is available from [this](https://github.com/mayadata-io/volume-events-exporter/pull/2/commits/82a95a7bce1a86767d34920e4924e7e143dac541) commit.
- This can be merged only after merging 
   - #1 
   - https://github.com/openebs/dynamic-nfs-provisioner/pull/93
- Sanity test was successfully run on GithHub [actions](https://github.com/mittachaitu/volume-events-exporter/runs/3399197248?check_suite_focus=true#step:8:1).