### PR TITLE
test(bdd): update workaround of manually marking NFS volume to export

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.5
+
       - name: Unit test
         run: make test-coverage
 
@@ -71,10 +76,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.7
+          go-version: 1.16.5
 
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.3.0

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -50,6 +50,11 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.5
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -96,10 +101,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up Go 1.15
+      - name: Set up Go 1.16
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.7
+          go-version: 1.16.5
 
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.3.0

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.so
 *.dylib
 
+# Ignore hook_types file which is downloaded from
+# https://raw.githubusercontent.com/openebs/dynamic-nfs-provisioner/HEAD/pkg/hook/types.go
+tests/hook_types.go
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,7 @@
 run:
   skip-files:
     - "tests/k8s_utils.go"
+    - "tests/hook_types.go"
 linters-settings:
   revive:
     ignore-generated-header: true

--- a/Makefile
+++ b/Makefile
@@ -146,10 +146,13 @@ volume-events-exporter-image: volume-events-exporter-bin
 ##          https://golangci-lint.run/usage/install/#install-from-source
 ##
 ## Install golangci-lint only if tool doesn't exist in system
+## Fetch hook_types from openebs/dynamic-nfs-provisioner
 .PHONY: bootstrap
 bootstrap:
 	@echo "Install golangci-lint tool"
 	$(if $(shell which golangci-lint), @echo "golangci-lint already exist in system", (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b "${GOPATH}/bin" v1.40.1))
+	wget https://raw.githubusercontent.com/openebs/dynamic-nfs-provisioner/HEAD/pkg/hook/types.go -O tests/hook_types.go
+	sed -i 's/package hook/package tests/g' tests/hook_types.go
 
 ## Currently we are running with Default options + other options
 ## Explanation for explicitly mentioned linters:
@@ -188,8 +191,6 @@ license-check:
 .PHONY: sanity-test
 sanity-test: sanity-test
 	@echo "--> Running sanity test";
-	wget https://raw.githubusercontent.com/openebs/dynamic-nfs-provisioner/HEAD/pkg/hook/types.go -O tests/hook_types.go
-	sed -i 's/package hook/package tests/g' tests/hook_types.go
 	go test -v -timeout 40m ./tests/...
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,8 @@ license-check:
 .PHONY: sanity-test
 sanity-test: sanity-test
 	@echo "--> Running sanity test";
+	wget https://raw.githubusercontent.com/openebs/dynamic-nfs-provisioner/HEAD/pkg/hook/types.go -O tests/hook_types.go
+	sed -i 's/package hook/package tests/g' tests/hook_types.go
 	go test -v -timeout 40m ./tests/...
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,8 @@ deps:
 	@go mod tidy
 	@echo "--> Veryfying submodules"
 	@go mod verify
+	wget https://raw.githubusercontent.com/openebs/dynamic-nfs-provisioner/HEAD/pkg/hook/types.go -O tests/hook_types.go
+	sed -i 's/package hook/package tests/g' tests/hook_types.go
 
 .PHONY: verify-deps
 verify-deps: deps
@@ -105,7 +107,7 @@ test-coverage: format vet
 	$(PWD)/buildscripts/test.sh ${XC_ARCH}
 
 .PHONY: vet
-vet:
+vet: deps
 	@echo "--> Running go vet"
 	@go list ./... | grep -v "./vendor/*" | xargs go vet -composites
 
@@ -151,8 +153,6 @@ volume-events-exporter-image: volume-events-exporter-bin
 bootstrap:
 	@echo "Install golangci-lint tool"
 	$(if $(shell which golangci-lint), @echo "golangci-lint already exist in system", (curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b "${GOPATH}/bin" v1.40.1))
-	wget https://raw.githubusercontent.com/openebs/dynamic-nfs-provisioner/HEAD/pkg/hook/types.go -O tests/hook_types.go
-	sed -i 's/package hook/package tests/g' tests/hook_types.go
 
 ## Currently we are running with Default options + other options
 ## Explanation for explicitly mentioned linters:
@@ -189,7 +189,7 @@ license-check:
 	@echo
 
 .PHONY: sanity-test
-sanity-test: sanity-test
+sanity-test: deps
 	@echo "--> Running sanity test";
 	go test -v -timeout 40m ./tests/...
 

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,9 @@ deps:
 	@go mod tidy
 	@echo "--> Veryfying submodules"
 	@go mod verify
-	wget https://raw.githubusercontent.com/openebs/dynamic-nfs-provisioner/HEAD/pkg/hook/types.go -O tests/hook_types.go
-	sed -i 's/package hook/package tests/g' tests/hook_types.go
+	@echo "--> Downloading hook definition for nfs-provisioner"
+	@wget -q https://raw.githubusercontent.com/openebs/dynamic-nfs-provisioner/HEAD/pkg/hook/types.go -O tests/hook_types.go
+	@sed -i 's/package hook/package tests/g' tests/hook_types.go
 
 .PHONY: verify-deps
 verify-deps: deps

--- a/buildscripts/test.sh
+++ b/buildscripts/test.sh
@@ -33,7 +33,6 @@ fi
 
 PACKAGES=$(go list ./... | grep -v '/vendor/\|/pkg/apis/\|/pkg/client/\|tests')
 for d in $PACKAGES; do
-    echo "Running for $d"
 	go test -coverprofile=profile.out -covermode=atomic "$d"
 	if [ -f profile.out ]; then
 		cat profile.out >> coverage.txt

--- a/buildscripts/test.sh
+++ b/buildscripts/test.sh
@@ -33,6 +33,7 @@ fi
 
 PACKAGES=$(go list ./... | grep -v '/vendor/\|/pkg/apis/\|/pkg/client/\|tests')
 for d in $PACKAGES; do
+    echo "Running for $d"
 	go test -coverprofile=profile.out -covermode=atomic "$d"
 	if [ -f profile.out ]; then
 		cat profile.out >> coverage.txt

--- a/deploy/kubectl/openebs-nfs-provisioner.yaml
+++ b/deploy/kubectl/openebs-nfs-provisioner.yaml
@@ -142,6 +142,9 @@ spec:
         # while creating nfs volume
         - name: OPENEBS_IO_NFS_SERVER_IMG
           value: openebs/nfs-server-alpine:ci
+        # OPENEBS_IO_NFS_HOOK_CONFIGMAP defines configmap to use for hook
+        - name: OPENEBS_IO_NFS_HOOK_CONFIGMAP
+          value: "hook-config"
         # LEADER_ELECTION_ENABLED is used to enable/disable leader election. By default
         # leader election is enabled.
         #- name: LEADER_ELECTION_ENABLED
@@ -182,6 +185,34 @@ spec:
         # to some higher value
         #- name: RESYNC_INTERVAL
         #  value: "120"
+---
+## hook-config.data.config is used to tag volumes
+## provisioned by NFS provisioner. Volume-event-exporter
+## will reconcile tagged volume and export information to
+## configured server. Once information is exported finalizers
+## on resources will be removed by volume-event-exporter
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hook-config
+  namespace: openebs
+data:
+  config: |
+    hooks:
+      addOrUpdateEntriesOnCreateVolumeEvent:
+        backendPV:
+          finalizers:
+          - nfs.events.openebs.io/finalizer
+        backendPVC:
+          finalizers:
+          - nfs.events.openebs.io/finalizer
+        nfsPV:
+          annotations:
+            events.openebs.io/required: "true"
+          finalizers:
+          - nfs.events.openebs.io/finalizer
+        name: createHook
+    version: 1.0.0
 ---
 #Sample storage classes for OpenEBS Local PV
 apiVersion: storage.k8s.io/v1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680
+	github.com/ghodss/yaml v1.0.0
 	github.com/google/go-cmp v0.5.4
 	github.com/gorilla/mux v1.8.0
 	github.com/onsi/ginkgo v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -62,7 +62,6 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoD
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
-github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680 h1:ZktWZesgun21uEDrwW7iEV1zPCGQldM2atlJZ3TdvVM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680 h1:ZktWZesgun21uEDrwW7iEV1zPCGQldM2atlJZ3TdvVM=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=

--- a/tests/k8s_utils.go
+++ b/tests/k8s_utils.go
@@ -224,6 +224,14 @@ func (k *KubeClient) destroyNamespace(namespace string) error {
 	return nil
 }
 
+func (k *KubeClient) getConfigMap(configNamespace, configName string) (*corev1.ConfigMap, error) {
+	return k.CoreV1().ConfigMaps(configNamespace).Get(context.TODO(), configName, metav1.GetOptions{})
+}
+
+func (k *KubeClient) updateConfigMap(config *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return k.CoreV1().ConfigMaps(config.Namespace).Update(context.TODO(), config, metav1.UpdateOptions{})
+}
+
 func (k *KubeClient) waitForPVCBound(ns, pvcName string) (corev1.PersistentVolumeClaimPhase, error) {
 	for {
 		o, err := k.CoreV1().

--- a/tests/nfs_create_retain_pv_disable_exporter_test.go
+++ b/tests/nfs_create_retain_pv_disable_exporter_test.go
@@ -42,9 +42,6 @@ var _ = Describe("TEST RETAINED NFS PVC CREATE EVENTS WHILE EXPORTER IS DISABLED
 		backendPVCName       string
 		backendPVName        string
 
-		// backend pvc configuration
-		integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
-
 		scNfsServerType = "kernel"
 
 		maxRetryCount = 15

--- a/tests/nfs_create_retain_pv_disable_exporter_test.go
+++ b/tests/nfs_create_retain_pv_disable_exporter_test.go
@@ -111,10 +111,6 @@ var _ = Describe("TEST RETAINED NFS PVC CREATE EVENTS WHILE EXPORTER IS DISABLED
 			pvcPhase, err := Client.waitForPVCBound(applicationNamespace, pvcName)
 			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
 			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
-
-			// TODO: Remove below lines after merging https://github.com/openebs/dynamic-nfs-provisioner/pull/97 PR
-			err = markNFSResources(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while marking for events")
 		})
 	})
 

--- a/tests/nfs_delete_released_pv_disable_exporter_test.go
+++ b/tests/nfs_delete_released_pv_disable_exporter_test.go
@@ -43,9 +43,6 @@ var _ = Describe("TEST DELETE EVENTS FOR RELEASED NFS PV WHILE EXPORTER IS DISAB
 		backendPVCName       string
 		backendPVName        string
 
-		// backend pvc configuration
-		integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
-
 		scNfsServerType = "kernel"
 
 		maxRetryCount = 15

--- a/tests/nfs_delete_released_pv_disable_exporter_test.go
+++ b/tests/nfs_delete_released_pv_disable_exporter_test.go
@@ -105,10 +105,6 @@ var _ = Describe("TEST DELETE EVENTS FOR RELEASED NFS PV WHILE EXPORTER IS DISAB
 			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
 			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
 
-			// TODO: Remove below lines after merging https://github.com/openebs/dynamic-nfs-provisioner/pull/97 PR
-			err = markNFSResources(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while marking for events")
-
 			pvcObj, err := Client.getPVC(applicationNamespace, pvcName)
 			Expect(err).To(BeNil(), "while fetching pvc %s/%s", applicationNamespace, pvcName)
 			nfsPVName = pvcObj.Spec.VolumeName

--- a/tests/nfs_delete_retain_pv_disable_exporter_test.go
+++ b/tests/nfs_delete_retain_pv_disable_exporter_test.go
@@ -42,9 +42,6 @@ var _ = Describe("TEST DELETE EVENTS FOR RETAIN NFS PVC WHILE EXPORTER IS DISABL
 		backendPVCName       string
 		backendPVName        string
 
-		// backend pvc configuration
-		integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
-
 		scNfsServerType = "kernel"
 
 		maxRetryCount = 15

--- a/tests/nfs_delete_retain_pv_disable_exporter_test.go
+++ b/tests/nfs_delete_retain_pv_disable_exporter_test.go
@@ -111,10 +111,6 @@ var _ = Describe("TEST DELETE EVENTS FOR RETAIN NFS PVC WHILE EXPORTER IS DISABL
 			pvcPhase, err := Client.waitForPVCBound(applicationNamespace, pvcName)
 			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
 			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
-
-			// TODO: Remove below lines after merging https://github.com/openebs/dynamic-nfs-provisioner/pull/97 PR
-			err = markNFSResources(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while marking for events")
 		})
 	})
 

--- a/tests/nfs_pvc_create_delete_disabling_sidecar_test.go
+++ b/tests/nfs_pvc_create_delete_disabling_sidecar_test.go
@@ -40,9 +40,6 @@ var _ = Describe("TEST NFS PVC CREATE AND DELETE WHEN VOLUME-EVENT-EXPORTER SIDE
 		backendPVCName string
 		backendPVName  string
 
-		// backend pvc configuration
-		integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
-
 		maxRetryCount = 15
 	)
 

--- a/tests/nfs_pvc_create_delete_disabling_sidecar_test.go
+++ b/tests/nfs_pvc_create_delete_disabling_sidecar_test.go
@@ -76,10 +76,6 @@ var _ = Describe("TEST NFS PVC CREATE AND DELETE WHEN VOLUME-EVENT-EXPORTER SIDE
 			pvcPhase, err := Client.waitForPVCBound(applicationNamespace, pvcName)
 			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
 			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
-
-			// TODO: Remove below lines after merging https://github.com/openebs/dynamic-nfs-provisioner/pull/97 PR
-			err = markNFSResources(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while makrking for events")
 		})
 	})
 

--- a/tests/nfs_pvc_creation_scaling_down_sidecar_test.go
+++ b/tests/nfs_pvc_creation_scaling_down_sidecar_test.go
@@ -39,9 +39,6 @@ var _ = Describe("TEST NFS PVC CREATE WHEN VOLUME-EVENT-EXPORTER SIDE CAR IS NOT
 		backendPVCName string
 		backendPVName  string
 
-		// backend pvc configuration
-		integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
-
 		maxRetryCount = 15
 	)
 

--- a/tests/nfs_pvc_creation_scaling_down_sidecar_test.go
+++ b/tests/nfs_pvc_creation_scaling_down_sidecar_test.go
@@ -75,10 +75,6 @@ var _ = Describe("TEST NFS PVC CREATE WHEN VOLUME-EVENT-EXPORTER SIDE CAR IS NOT
 			pvcPhase, err := Client.waitForPVCBound(applicationNamespace, pvcName)
 			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
 			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
-
-			// TODO: Remove below lines after merging https://github.com/openebs/dynamic-nfs-provisioner/pull/97 PR
-			err = markNFSResources(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while makrking for events")
 		})
 	})
 

--- a/tests/nfs_pvc_invalid_backend_sc_test.go
+++ b/tests/nfs_pvc_invalid_backend_sc_test.go
@@ -45,9 +45,6 @@ var _ = Describe("TEST NFS PVC WITH INVALID BACKEND STORAGECLASS", func() {
 		scName         = "openebs-rwx-invalid-backend-sc"
 		backendPVCName string
 
-		// backend pvc configuration
-		integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
-
 		maxRetryCount = 15
 	)
 
@@ -210,11 +207,14 @@ var _ = Describe("TEST NFS PVC WITH INVALID BACKEND STORAGECLASS", func() {
 			backendPVCObj, err := Client.getPVC(OpenEBSNamespace, backendPVCName)
 			Expect(err).To(BeNil(), "while fetching backend pvc %s/%s", OpenEBSNamespace, backendPVCName)
 
+			var finalizers []string
 			for index := range backendPVCObj.Finalizers {
-				if backendPVCObj.Finalizers[index] == integrationTestFinalizer {
-					backendPVCObj.Finalizers = append(backendPVCObj.Finalizers[:index], backendPVCObj.Finalizers[index+1:]...)
+				if backendPVCObj.Finalizers[index] != integrationTestFinalizer {
+					finalizers = append(finalizers, backendPVCObj.Finalizers[index])
 				}
 			}
+			backendPVCObj.Finalizers = finalizers
+
 			_, err = Client.updatePVC(backendPVCObj)
 			Expect(err).To(BeNil(), "while removing %s finlaizer to pvc %s/%s", integrationTestFinalizer, OpenEBSNamespace, backendPVCName)
 		})

--- a/tests/nfs_pvc_retain_test.go
+++ b/tests/nfs_pvc_retain_test.go
@@ -46,9 +46,6 @@ var _ = Describe("TEST NFS PVC WITH RETAIN RECLAIM POLICY", func() {
 		backendPVCName string
 		backendPVName  string
 
-		// backend pvc configuration
-		integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
-
 		maxRetryCount = 15
 	)
 

--- a/tests/nfs_pvc_retain_test.go
+++ b/tests/nfs_pvc_retain_test.go
@@ -106,9 +106,6 @@ var _ = Describe("TEST NFS PVC WITH RETAIN RECLAIM POLICY", func() {
 			pvcPhase, err := Client.waitForPVCBound(applicationNamespace, pvcName)
 			Expect(err).To(BeNil(), "while waiting for pvc %s/%s bound phase", applicationNamespace, pvcName)
 			Expect(pvcPhase).To(Equal(corev1.ClaimBound), "pvc %s/%s should be in bound phase", applicationNamespace, pvcName)
-
-			err = markNFSResources(applicationNamespace, pvcName)
-			Expect(err).To(BeNil(), "while makrking for events")
 		})
 	})
 

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -63,7 +63,13 @@ var (
 	// to create the data(export) directory for NFS server
 	KeyPVBackendStorageClass = "BackendStorageClass"
 
-	// backend pvc configuration for integration test
+	// integrationTestFinalizer will be configured only on backend PVC.
+	// This finalizer is required for test to ensure whether volume events
+	// (create/delete) are exported to server, once the server receives a volume
+	// event will add received `metadata.name` as an annotation on backend PVC,
+	// Since the finalizer exist test will be able to verify annotations
+	// of occurred events and if everything is good, test will remove finalizer
+	// manually
 	integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
 )
 

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/mayadata-io/volume-events-exporter/tests/nfs"
 	"github.com/mayadata-io/volume-events-exporter/tests/server"
 	"github.com/mayadata-io/volume-events-exporter/tests/server/rest"
@@ -52,6 +53,7 @@ var (
 	nfsProvisionerName          = "openebs-nfs-provisioner"
 	nfsProvisionerLabelSelector = "openebs.io/component-name=openebs-nfs-provisioner"
 	OpenEBSNamespace            = "openebs"
+	nfsHookConfigName           = "hook-config"
 
 	//KeyPVNFSServerType defines if the NFS PV should be launched
 	// using kernel or ganesha
@@ -60,6 +62,9 @@ var (
 	//KeyPVBackendStorageClass defines default provisioner to be used
 	// to create the data(export) directory for NFS server
 	KeyPVBackendStorageClass = "BackendStorageClass"
+
+	// backend pvc configuration for integration test
+	integrationTestFinalizer = "it.nfs.openebs.io/test-protection"
 )
 
 func TestSource(t *testing.T) {
@@ -96,6 +101,9 @@ var _ = BeforeSuite(func() {
 	By("waiting for openebs-nfs-provisioner pod to come into running state")
 	err = Client.waitForPods(OpenEBSNamespace, nfsProvisionerLabelSelector, corev1.PodRunning, 1)
 	Expect(err).To(BeNil(), "while waiting for nfs deployment to be ready")
+
+	err = updateNFSHookConfig(OpenEBSNamespace, nfsHookConfigName)
+	Expect(err).To(BeNil(), "while updating nfs hook configuration as required per test")
 
 	err = addEventControllerSideCar(OpenEBSNamespace, nfsProvisionerName)
 	Expect(err).To(BeNil(), "while adding volume-event-exporter sidecar")
@@ -209,6 +217,40 @@ func removeEventsCollectorSidecar(deploymentNamespace, deploymentName string) er
 		return err
 	}
 	return Client.waitForDeploymentRollout(updatedDeployObj.Namespace, updatedDeployObj.Name)
+}
+
+// updateNFSHookConfig will update the NFS hook configuration as
+// per test details
+func updateNFSHookConfig(namespace, name string) error {
+	hookConfigMap, err := Client.getConfigMap(namespace, name)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get configmap %s/%s", namespace, name)
+	}
+	var hook Hook
+	hookData, isConfigExist := hookConfigMap.Data["config"]
+	if !isConfigExist {
+		return errors.Errorf("hook configmap=%s/%s doesn't have data field=%s", namespace, name, "config")
+	}
+
+	err = yaml.Unmarshal([]byte(hookData), &hook)
+	if err != nil {
+		return err
+	}
+	addHookConfig, isAddExist := hook.Config[ActionAddOnCreateVolumeEvent]
+	if !isAddExist {
+		return errors.Errorf("%s configuration doesn't exist in hook %s/%s", ActionAddOnCreateVolumeEvent, namespace, name)
+	}
+	addHookConfig.BackendPVCConfig.Finalizers = append(addHookConfig.BackendPVCConfig.Finalizers, integrationTestFinalizer)
+	hook.Config[ActionAddOnCreateVolumeEvent] = addHookConfig
+
+	updatedHookConfigInBytes, err := yaml.Marshal(hook)
+	if err != nil {
+		return err
+	}
+
+	hookConfigMap.Data["config"] = string(updatedHookConfigInBytes)
+	_, err = Client.updateConfigMap(hookConfigMap)
+	return err
 }
 
 // externalIP will fetch the IP from ifconfig


### PR DESCRIPTION
This PR updates the integration test to remove manual marking of
NFS volumes to export volume event information.

Fixes: #5 

Signed-off-by: mittachaitu <sai.chaithanya@mayadata.io>